### PR TITLE
Autoload the add-zsh-hook function

### DIFF
--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -141,6 +141,7 @@ function _per-directory-history-set-global-history() {
 
 
 #add functions to the exec list for chpwd and zshaddhistory
+autoload -U add-zsh-hook
 add-zsh-hook chpwd _per-directory-history-change-directory
 add-zsh-hook zshaddhistory _per-directory-history-addhistory
 


### PR DESCRIPTION
This is a fix for the following error:

```bash
~/.oh-my-zsh/plugins/per-directory-history/per-directory-history.plugin.zsh:144: command not found: add-zsh-hook
~/.oh-my-zsh/plugins/per-directory-history/per-directory-history.plugin.zsh:145: command not found: add-zsh-hook
```
