### PR TITLE
Use per-directory history in new shell

### DIFF
--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -126,6 +126,15 @@ function _per-directory-history-addhistory() {
   fi
 }
 
+function _per-directory-history-precmd() {
+  if [[ $_per_directory_history_initialized == false ]]; then
+    # start in directory mode
+    mkdir -p ${_per_directory_history_directory:h}
+    _per_directory_history_is_global=$HISTORY_START_WITH_GLOBAL
+    [[ $_per_directory_history_is_global == true ]] && _per-directory-history-set-global-history || _per-directory-history-set-directory-history
+    _per_directory_history_initialized=true
+  fi
+}
 
 function _per-directory-history-set-directory-history() {
   if [[ $_per_directory_history_is_global == true ]]; then
@@ -157,8 +166,7 @@ function _per-directory-history-set-global-history() {
 autoload -U add-zsh-hook
 add-zsh-hook chpwd _per-directory-history-change-directory
 add-zsh-hook zshaddhistory _per-directory-history-addhistory
+add-zsh-hook precmd _per-directory-history-precmd
 
-#start in directory mode
-mkdir -p ${_per_directory_history_directory:h}
-_per_directory_history_is_global=$HISTORY_START_WITH_GLOBAL
-[[ $_per_directory_history_is_global == true ]] && _per-directory-history-set-global-history || _per-directory-history-set-directory-history
+# set initialized flag to false
+_per_directory_history_initialized=false


### PR DESCRIPTION
This patch fixes the problem that in a newly created shell, the global history would be used instead of the per-directory on. It does this by delaying the loading of the per-directory history until just before the prompt is created.

This PR fixes issue #5.