### PR TITLE
Fix per directory history not being activated

### DIFF
--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -32,7 +32,7 @@
 #
 # Copyright (c) 2014 Jim Hester
 #
-# This software is provided 'as-is', without any express or implied warranty. 
+# This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the
 # use of this software.
 #
@@ -67,9 +67,11 @@
 function per-directory-history-toggle-history() {
   if [[ $_per_directory_history_is_global == true ]]; then
     _per-directory-history-set-directory-history
+    _per_directory_history_is_global=false
     print -n "\nusing local history"
   else
     _per-directory-history-set-global-history
+    _per_directory_history_is_global=true
     print -n "\nusing global history"
   fi
   zle .push-line
@@ -128,39 +130,39 @@ function _per-directory-history-addhistory() {
 
 function _per-directory-history-precmd() {
   if [[ $_per_directory_history_initialized == false ]]; then
-    # start in directory mode
-    mkdir -p ${_per_directory_history_directory:h}
-    _per_directory_history_is_global=$HISTORY_START_WITH_GLOBAL
-    [[ $_per_directory_history_is_global == true ]] && _per-directory-history-set-global-history || _per-directory-history-set-directory-history
     _per_directory_history_initialized=true
+
+    if [[ $HISTORY_START_WITH_GLOBAL == true ]]; then
+      _per-directory-history-set-global-history
+      _per_directory_history_is_global=true
+    else
+      _per-directory-history-set-directory-history
+      _per_directory_history_is_global=false
+    fi
   fi
 }
 
 function _per-directory-history-set-directory-history() {
-  if [[ $_per_directory_history_is_global == true ]]; then
-    fc -AI $HISTFILE
-    local original_histsize=$HISTSIZE
-    HISTSIZE=0
-    HISTSIZE=$original_histsize
-    if [[ -e "$_per_directory_history_directory" ]]; then
-      fc -R "$_per_directory_history_directory"
-    fi
+  fc -AI $HISTFILE
+  local original_histsize=$HISTSIZE
+  HISTSIZE=0
+  HISTSIZE=$original_histsize
+  if [[ -e "$_per_directory_history_directory" ]]; then
+    fc -R "$_per_directory_history_directory"
   fi
-  _per_directory_history_is_global=false
-}
-function _per-directory-history-set-global-history() {
-  if [[ $_per_directory_history_is_global == false ]]; then
-    fc -AI $_per_directory_history_directory
-    local original_histsize=$HISTSIZE
-    HISTSIZE=0
-    HISTSIZE=$original_histsize
-    if [[ -e "$HISTFILE" ]]; then
-      fc -R "$HISTFILE"
-    fi
-  fi
-  _per_directory_history_is_global=true
 }
 
+function _per-directory-history-set-global-history() {
+  fc -AI $_per_directory_history_directory
+  local original_histsize=$HISTSIZE
+  HISTSIZE=0
+  HISTSIZE=$original_histsize
+  if [[ -e "$HISTFILE" ]]; then
+    fc -R "$HISTFILE"
+  fi
+}
+
+mkdir -p ${_per_directory_history_directory:h}
 
 #add functions to the exec list for chpwd and zshaddhistory
 autoload -U add-zsh-hook


### PR DESCRIPTION
Because of the guards in the switch functions and with
HISTORY_START_WITH_GLOBAL being false by default, the per directory
history was not active after initialisation.

During initialisation, _per_directory_history_is_global was false and
_per-directory-history-set-directory-history was called but wouldn't do
anything. Only toggling twice would enable per directory history.

This commit removes the guards and restructures the code slightly to
make HISTORY_START_WITH_GLOBAL being false and true work from the
beginning.