### PR TITLE
fix: Support "zplug" plug-in installation

### DIFF
--- a/per-directory-history.plugin.zsh
+++ b/per-directory-history.plugin.zsh
@@ -1,1 +1,1 @@
-per-directory-history.zsh
+source ${0:h}/per-directory-history.zsh


### PR DESCRIPTION
Installation via zplug prompts that per-directory-historyper- cannot be loaded.

**.zshrc**

```bash
source ~/.zplug/init.zsh

zplug "jimhester/per-directory-history"

zplug load --verbose
```

error:
WARNING:  Failed to load "~/.zplug/repos/jimhester/per-directory-history/per-directory-history.plugin.zsh" (jimhester/per-directory-history)
