### PR TITLE
Feature: Aggregated logs in single file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#IDE's files
+.idea

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Usage
 Configuration
 -------------------------------------------------------------------------------
 
-* HISTORY_BASE a global variable that defines the base directory in which the 
+* `HISTORY_BASE` a global variable that defines the base directory in which the 
   directory histories are stored
-* PER_DIRECTORY_AGGREGATED_PATH if exist then fixed history file path is used:
+* `PER_DIRECTORY_AGGREGATED_PATH` if exist then fixed history file path is used:
   `$HISTORY_BASE/$PER_DIRECTORY_AGGREGATED_PATH`
-  Good if you would like to keep your history aggregated for multiple directories 
+  
+  Good if you would like to keep your history aggregated for multiple directories
   (use `direnv` to set that ENV depended on the directory)
-* per-directory-history-toggle-history is the function to toggle the history
+* `per-directory-history-toggle-history` is the function to toggle the history
 
 -------------------------------------------------------------------------------
 History

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Configuration
 
 * HISTORY_BASE a global variable that defines the base directory in which the 
   directory histories are stored
+* PER_DIRECTORY_AGGREGATED_PATH if exist then fixed history file path is used:
+  `$HISTORY_BASE/$PER_DIRECTORY_AGGREGATED_PATH`
+  Good if you would like to keep your history aggregated for multiple directories 
+  (use `direnv` to set that ENV depended on the directory)
 * per-directory-history-toggle-history is the function to toggle the history
 
 -------------------------------------------------------------------------------

--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -56,7 +56,7 @@
 # configuration, the base under which the directory histories are stored
 #-------------------------------------------------------------------------------
 
-[[ -z $HISTORY_BASE ]] && HISTORY_BASE="$HOME/.directory_history"
+[[ -z $HISTORY_BASE ]] && HISTORY_BASE="$HOME/.config/directory_history"
 [[ -z $HISTORY_START_WITH_GLOBAL ]] && HISTORY_START_WITH_GLOBAL=false
 [[ -z $PER_DIRECTORY_HISTORY_TOGGLE ]] && PER_DIRECTORY_HISTORY_TOGGLE='^G'
 
@@ -85,17 +85,30 @@ bindkey $PER_DIRECTORY_HISTORY_TOGGLE per-directory-history-toggle-history
 #-------------------------------------------------------------------------------
 # implementation details
 #-------------------------------------------------------------------------------
-
-_per_directory_history_directory="$HISTORY_BASE${PWD:A}/history"
+function load_dir_history_path() {
+    if [[ -z $PER_DIRECTORY_AGGREGATED_PATH ]]
+    then
+      _per_directory_history_directory="$HISTORY_BASE${PWD:A}/history"
+    else
+      _per_directory_history_directory="$HISTORY_BASE/$PER_DIRECTORY_AGGREGATED_PATH"
+    fi
+}
+load_dir_history_path
 
 function _per-directory-history-change-directory() {
-  _per_directory_history_directory="$HISTORY_BASE${PWD:A}/history"
+  load_dir_history_path
   mkdir -p ${_per_directory_history_directory:h}
   if [[ $_per_directory_history_is_global == false ]]; then
     #save to the global history
     fc -AI $HISTFILE
+
     #save history to previous file
-    local prev="$HISTORY_BASE${OLDPWD:A}/history"
+    if [[ -z $PER_DIRECTORY_AGGREGATED_PATH ]]
+    then
+      local prev="$HISTORY_BASE${OLDPWD:A}/history"
+    else
+      local prev=$_per_directory_history_directory
+    fi
     mkdir -p ${prev:h}
     fc -AI $prev
 


### PR DESCRIPTION
It lets to use one history file for multiple directories by setting `PER_DIRECTORY_AGGREGATED_PATH` env (use `direnv` to set that in your directories accordingly) 