### PR TITLE
bind ^G to history mode toggle regardless of vi mode

### DIFF
--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -81,6 +81,7 @@ function per-directory-history-toggle-history() {
 autoload per-directory-history-toggle-history
 zle -N per-directory-history-toggle-history
 bindkey $PER_DIRECTORY_HISTORY_TOGGLE per-directory-history-toggle-history
+bindkey -M vicmd $PER_DIRECTORY_HISTORY_TOGGLE per-directory-history-toggle-history
 
 #-------------------------------------------------------------------------------
 # implementation details


### PR DESCRIPTION
Fixes bug whereby ^G keybinding did not work in `bindkey -v` command mode.

This PR is parallel to [this one](https://github.com/ohmyzsh/ohmyzsh/pull/11808), which fixes the same bug in the Oh-My-Zsh version of the `per-directory-history` plugin.